### PR TITLE
Support TLS and download files asynchronously.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache: pip
 
 install:
   - pip install -r requirements.txt
-  - pip install -U pytest pytest-twisted pytest-cov pytest-pep8 coveralls requests-mock attrs>=19.2.0
+  - pip install -U pytest pytest-twisted pytest-cov pytest-pep8 coveralls pytest-mock attrs>=19.2.0
 
 script:
   - pytest --cov=kiosk_client --pep8 kiosk_client

--- a/kiosk_client/job.py
+++ b/kiosk_client/job.py
@@ -185,7 +185,6 @@ class Job(object):
         req_kwargs = {
             'headers': kwargs.get('headers', self.headers),
             'pool': kwargs.get('pool', self.pool),
-            'browser_like_redirects': True,
         }
 
         # The name of the payload dictates the type of encoding and headers.

--- a/kiosk_client/job.py
+++ b/kiosk_client/job.py
@@ -184,6 +184,7 @@ class Job(object):
         req_kwargs = {
             'headers': kwargs.get('headers', self.headers),
             'pool': kwargs.get('pool', self.pool),
+            'browser_like_redirects': True,
         }
 
         # The name of the payload dictates the type of encoding and headers.

--- a/kiosk_client/job_test.py
+++ b/kiosk_client/job_test.py
@@ -385,14 +385,13 @@ class TestJob(object):
         assert value is False  # failed
 
     @pytest_twisted.inlineCallbacks
-    def test__retry_post_request_wrapper(self):
+    def test__retry_post_request_wrapper(self, mocker):
 
         global _make_request_failed
         _make_request_failed = False
 
         @pytest_twisted.inlineCallbacks
-        def _make_post_request(*_, **__):
-            _j = _get_default_job()
+        def dummy_post_request(*_, **__):
             global _make_request_failed
             if _make_request_failed:
                 _make_request_failed = False
@@ -404,7 +403,6 @@ class TestJob(object):
                 raise err('on purpose')
 
         j = _get_default_job()
-        j._make_post_request = _make_post_request
-
+        mocker.patch('treq.post', dummy_post_request)
         result = yield j._retry_post_request_wrapper('host', {})
         assert result.get('success')

--- a/kiosk_client/job_test.py
+++ b/kiosk_client/job_test.py
@@ -35,7 +35,6 @@ import timeit
 
 import pytest
 import pytest_twisted
-from treq.testing import StubTreq
 
 from twisted.internet import defer
 

--- a/kiosk_client/manager_test.py
+++ b/kiosk_client/manager_test.py
@@ -169,24 +169,12 @@ class TestJobManager(object):
         # monkey-patches for testing
         mgr.cost_getter.finish = lambda: (1, 2, 3)
         mgr.upload_file = fake_upload_file
-        mgr.download_file_from_url = fake_download_file
         mgr.summarize()
 
         # test Exceptions
         mgr.cost_getter.finish = lambda: 0 / 1
         mgr.upload_file = fake_upload_file_bad
-        mgr.download_file_from_url = fake_download_file_bad
         mgr.summarize()
-
-    def test_download_file_from_url(self, tmpdir, requests_mock):
-        tmpdir = str(tmpdir)
-        expected_file = os.path.join(tmpdir, 'downloaded.txt')
-        requests_mock.get('http://test.com', text='data')
-
-        mgr = manager.BenchmarkingJobManager(host='localhost', job_type='job')
-        mgr.download_file_from_url('http://test.com', expected_file)
-        assert os.path.exists(expected_file)
-        assert os.path.isfile(expected_file)
 
     @pytest_twisted.inlineCallbacks
     def test_check_job_status(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Pillow>=6.2.0
 python-decouple>=3.1,<4
 python-dateutil==2.8.0
 treq==20.3.0
-twisted>=20.3.0
+twisted[tls]>=20.3.0

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(name='Kiosk_Client',
                     'pytest-twisted',
                     'pytest-pep8',
                     'pytest-cov',
-                    'requests-mock',
+                    'pytest-mock',
                     'attrs>=19.2.0'],
       },
       packages=find_packages())

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(name='Kiosk_Client',
                         'python-decouple',
                         'python-dateutil==2.8.0',
                         'treq==20.3.0',
-                        'twisted>=20.3.0'],
+                        'twisted[tls]>=20.3.0'],
       extras_require={
           'tests': ['pytest',
                     'pytest-twisted',


### PR DESCRIPTION
Fixes #51 

Support TLS by installing `twisted[tls]` instead of `twisted`.  With TLS support, this PR supports downloading each output file asynchronously with `treq`.  This removes the need for `requests-mock` and instead we use `pytest-mock` to mock the `treq.get` requests. `test_retry_post_request` has also been improved using the `mock` plugin.