### PR TITLE
Minor improvements for pypi, badges, and logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Build Status](https://travis-ci.com/vanvalenlab/kiosk-client.svg?branch=master)](https://travis-ci.com/vanvalenlab/kiosk-client)
 [![Coverage Status](https://coveralls.io/repos/github/vanvalenlab/kiosk-client/badge.svg?branch=master)](https://coveralls.io/github/vanvalenlab/kiosk-client?branch=master)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](/LICENSE)
+[![PyPi](https://img.shields.io/pypi/v/kiosk_client.svg)](https://pypi.org/project/Kiosk-Client/)
+[![Python Versions](https://img.shields.io/pypi/pyversions/kiosk_client.svg)](https://pypi.org/project/kiosk_client/)
 
 `kiosk-client` is tool for interacting with the [DeepCell Kiosk](https://github.com/vanvalenlab/kiosk-console) in order to create and monitor deep learning image processing jobs. It uses the asynchronous HTTP client [treq](https://github.com/twisted/treq) and the [Kiosk-Frontend API](https://github.com/vanvalenlab/kiosk-frontend) to create and monitor many jobs at once. Once all jobs are completed, [costs are estimated](./docs/cost_computation_notes.md) by using the cluster's [Grafana API](https://grafana.com/docs/http_api/). An output file is then generated with statistics on each job's performance and resulting output files.
 

--- a/kiosk_client/__main__.py
+++ b/kiosk_client/__main__.py
@@ -178,6 +178,8 @@ def initialize_logger(log_level):
     fh.setLevel(log_level)
     logger.addHandler(fh)
 
+    logging.getLogger('PIL').setLevel(logging.INFO)
+
 
 if __name__ == '__main__':
     args = get_arg_parser().parse_args()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 google-cloud-storage>=1.12.0
 Pillow>=6.2.0
 python-decouple>=3.1,<4
-python-dateutil==2.8.0
+python-dateutil>=2.8.0,<3
 treq==20.3.0
 twisted[tls]>=20.3.0

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(name='Kiosk_Client',
                         'google-cloud-storage',
                         'Pillow',
                         'python-decouple',
-                        'python-dateutil==2.8.0',
+                        'python-dateutil',
                         'treq==20.3.0',
                         'twisted[tls]>=20.3.0'],
       extras_require={

--- a/setup.py
+++ b/setup.py
@@ -50,4 +50,14 @@ setup(name='Kiosk_Client',
                     'pytest-mock',
                     'attrs>=19.2.0'],
       },
-      packages=find_packages())
+      packages=find_packages(),
+      classifiers=[
+          'Programming Language :: Python',
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.8'
+      ])

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,12 @@
 from setuptools import setup
 from setuptools import find_packages
 
+# read the contents of your README file
+from os import path
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
 setup(name='Kiosk_Client',
       version='0.6.0',
       description='ClI client for the DeepCell Kiosk.',
@@ -51,6 +57,8 @@ setup(name='Kiosk_Client',
                     'attrs>=19.2.0'],
       },
       packages=find_packages(),
+      long_description=long_description,
+      long_description_content_type='text/markdown',
       classifiers=[
           'Programming Language :: Python',
           'Programming Language :: Python :: 2',


### PR DESCRIPTION
Update `setup.py` with Python version classifiers and add the PyPi and Python version badges to the README. Use the README as the long description for PyPi.

Loosen the version requirement on `python-dateutil`.

Set `PIL` logging to INFO level.