### PR TITLE
Use context manager while uploading files.

### DIFF
--- a/kiosk_client/job.py
+++ b/kiosk_client/job.py
@@ -230,7 +230,9 @@ class Job(object):
         headers['Content-Type'] = ['multipart/form-data']
         name = 'UPLOAD {}'.format(self.filepath)
         with open(self.filepath, 'rb') as f:
-            payload = {'file': (self.filepath, f)}
+            payload = {
+                'file': (self.filepath, f)
+            }
             response = yield self._retry_post_request_wrapper(host, name,
                                                               files=payload,
                                                               headers=headers)

--- a/kiosk_client/job.py
+++ b/kiosk_client/job.py
@@ -230,9 +230,7 @@ class Job(object):
         headers['Content-Type'] = ['multipart/form-data']
         name = 'UPLOAD {}'.format(self.filepath)
         with open(self.filepath, 'rb') as f:
-            payload = {
-                'file': (self.filepath, f)
-            }
+            payload = {'file': (self.filepath, f)}
             response = yield self._retry_post_request_wrapper(host, name,
                                                               files=payload,
                                                               headers=headers)

--- a/kiosk_client/job.py
+++ b/kiosk_client/job.py
@@ -229,13 +229,12 @@ class Job(object):
         headers = self.headers.copy()
         headers['Content-Type'] = ['multipart/form-data']
         name = 'UPLOAD {}'.format(self.filepath)
-        payload = {
-            'file': (self.filepath, open(self.filepath, 'rb'))
-        }
-        response = yield self._retry_post_request_wrapper(host, name,
-                                                          files=payload,
-                                                          headers=headers)
-        uploaded_path = response.get('uploadedName')
+        with open(self.filepath, 'rb') as f:
+            payload = {'file': (self.filepath, f)}
+            response = yield self._retry_post_request_wrapper(host, name,
+                                                              files=payload,
+                                                              headers=headers)
+            uploaded_path = response.get('uploadedName')
         defer.returnValue(uploaded_path)  # "return" the value
 
     @defer.inlineCallbacks

--- a/kiosk_client/job.py
+++ b/kiosk_client/job.py
@@ -234,7 +234,7 @@ class Job(object):
             response = yield self._retry_post_request_wrapper(host, name,
                                                               files=payload,
                                                               headers=headers)
-            uploaded_path = response.get('uploadedName')
+        uploaded_path = response.get('uploadedName')
         defer.returnValue(uploaded_path)  # "return" the value
 
     @defer.inlineCallbacks

--- a/kiosk_client/manager.py
+++ b/kiosk_client/manager.py
@@ -28,14 +28,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import io
 import json
 import logging
 import os
-import shutil
 import timeit
 import uuid
-import zipfile
 
 import requests
 from google.cloud import storage as google_storage


### PR DESCRIPTION
Use `with open(img_path, 'rb') as f` to make sure to close any open files automatically while uploading files.