### PR TITLE
Support --output-dir as a CLI argument.

### DIFF
--- a/kiosk_client/__main__.py
+++ b/kiosk_client/__main__.py
@@ -38,7 +38,6 @@ from twisted.internet import reactor
 
 from kiosk_client import manager
 from kiosk_client import settings
-from kiosk_client.utils import get_download_path
 
 
 def valid_filepath(parser, arg):
@@ -155,7 +154,7 @@ def get_arg_parser():
                         default=settings.UPLOAD_PREFIX,
                         help='Maximum number of connections to the Kiosk.')
 
-    parser.add_argument('--output-dir', default=get_download_path(),
+    parser.add_argument('--output-dir', default=settings.OUTPUT_DIR,
                         help='Directory to save the job output.')
 
     return parser

--- a/kiosk_client/__main__.py
+++ b/kiosk_client/__main__.py
@@ -38,6 +38,7 @@ from twisted.internet import reactor
 
 from kiosk_client import manager
 from kiosk_client import settings
+from kiosk_client.utils import get_download_path
 
 
 def valid_filepath(parser, arg):
@@ -154,6 +155,9 @@ def get_arg_parser():
                         default=settings.UPLOAD_PREFIX,
                         help='Maximum number of connections to the Kiosk.')
 
+    parser.add_argument('--output-dir', default=get_download_path(),
+                        help='Directory to save the job output.')
+
     return parser
 
 
@@ -211,6 +215,7 @@ if __name__ == '__main__':
         'upload_results': args.upload_results,
         'calculate_cost': args.calculate_cost,
         'download_results': not args.no_download_results,
+        'output_dir': args.output_dir,
     }
 
     if not os.path.exists(args.file) and not args.benchmark and args.upload:

--- a/kiosk_client/manager.py
+++ b/kiosk_client/manager.py
@@ -43,7 +43,8 @@ from kiosk_client.job import Job
 from kiosk_client.utils import iter_image_files
 from kiosk_client.utils import sleep
 from kiosk_client.utils import strip_bucket_prefix
-from kiosk_client import settings, job
+from kiosk_client.utils import get_download_path
+from kiosk_client import settings
 
 from kiosk_client.cost import CostGetter
 
@@ -113,7 +114,7 @@ class JobManager(object):
         self.download_results = kwargs.get('download_results', True)
         self.calculate_cost = kwargs.get('calculate_cost', False)
 
-        self.output_dir = kwargs.get('output_dir', job.get_download_path())
+        self.output_dir = kwargs.get('output_dir', get_download_path())
         if not os.path.isdir(self.output_dir):
             raise ValueError('Invalid value for output_dir,'
                              ' %s is not a directory.' % self.output_dir)
@@ -275,7 +276,7 @@ class JobManager(object):
         output_filepath = '{}{}jobs_{}delay_{}.json'.format(
             '{}gpu_'.format(settings.NUM_GPUS) if settings.NUM_GPUS else '',
             len(self.all_jobs), self.start_delay, uuid.uuid4().hex)
-        output_filepath = os.path.join(settings.OUTPUT_DIR, output_filepath)
+        output_filepath = os.path.join(self.output_dir, output_filepath)
 
         with open(output_filepath, 'w') as jsonfile:
             json.dump(jsondata, jsonfile, indent=4)

--- a/kiosk_client/manager_test.py
+++ b/kiosk_client/manager_test.py
@@ -198,11 +198,10 @@ class TestJobManager(object):
         def fake_download_file_bad(url, dest):
             return 1 / 0
 
-        settings.OUTPUT_DIR = str(tmpdir)
-
         mgr = manager.JobManager(host='localhost', job_type='job',
                                  upload_results=True,
-                                 calculate_cost=True)
+                                 calculate_cost=True,
+                                 output_dir=str(tmpdir))
 
         fakejson = lambda: {'output_url': 'example.com/json.txt'}
         mgr.all_jobs = [Bunch(output_url='example.com/a.txt', json=fakejson),

--- a/kiosk_client/settings.py
+++ b/kiosk_client/settings.py
@@ -33,6 +33,8 @@ import os
 
 from decouple import config
 
+from kiosk_client.utils import get_download_path
+
 
 NUM_GPUS = config('NUM_GPUS', cast=int, default=0)
 
@@ -83,7 +85,7 @@ CONCURRENT_REQUESTS_PER_HOST = config('CONCURRENT_REQUESTS_PER_HOST',
 # Application directories
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DOWNLOAD_DIR = os.path.join(ROOT_DIR, 'download')
-OUTPUT_DIR = os.path.join(ROOT_DIR, 'output')
+OUTPUT_DIR = get_download_path()
 LOG_DIR = os.path.join(ROOT_DIR, 'logs')
 
 # Log settings


### PR DESCRIPTION
This PR adds support for setting the `output_dir` via the CLI or environment variables. The `settings.OUTPUT_DIR` value defaults to the download directory, but can be overridden via the environment. This value in `settings` is then the default value of the CLI argument `--output-dir`.  This value is then passed into the `Manager` in the main script (which passes the value to `Job` as before).

Closes #65 