### PR TITLE
Fix tags in docker deployment workflow

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -33,8 +33,8 @@ jobs:
         file: ./Dockerfile
         push: true
         tags: |
-          {{ github.repository }}:latest
-          {{ github.repository }}:{{ github.ref }}
+          ${{ github.repository }}:latest
+          ${{ github.repository }}:${{ github.ref }}
     
     - name: Image digest
       run: echo ${{ steps.docker_build.outputs.digest }}

--- a/kiosk_client/__version__.py
+++ b/kiosk_client/__version__.py
@@ -27,7 +27,7 @@
 __title__ = 'Kiosk_Client'
 __description__ = 'CLI client for the DeepCell Kiosk.'
 __url__ = 'https://github.com/vanvalenlab/kiosk-client'
-__version__ = '0.8.2'
+__version__ = '0.8.3'
 __author__ = 'Van Valen Lab'
 __author_email__ = 'vanvalenlab@gmail.com'
 __license__ = 'LICENSE'


### PR DESCRIPTION
Docker tags were missing the `$` and could not be interpreted.