### PR TITLE
Update coverage reports to report individual OS/Python version combinations.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Run PyTest and Coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        COVERALLS_FLAG_NAME: python-${{ matrix.python-version }}
+        COVERALLS_FLAG_NAME: python-${{ matrix.os-version }}-${{ matrix.python-version }}
         COVERALLS_PARALLEL: true
       run: |
         pytest kiosk_client --cov kiosk_client --pep8

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Run PyTest and Coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        COVERALLS_FLAG_NAME: python-${{ matrix.os-version }}-${{ matrix.python-version }}
+        COVERALLS_FLAG_NAME: python-${{ matrix.os }}-${{ matrix.python-version }}
         COVERALLS_PARALLEL: true
       run: |
         pytest kiosk_client --cov kiosk_client --pep8


### PR DESCRIPTION
Set the `key` to `python-${{ matrix.os }}-${{ matrix.python-version }}` to split each run out.