### PR TITLE
Bump `treq` to 21.5.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ google-cloud-storage>=1.12.0
 Pillow>=6.2.0
 python-decouple>=3.1,<4
 python-dateutil>=2.8.0,<3
-treq==21.1.0
+treq==21.5.0


### PR DESCRIPTION
Upgrade `treq` to the [newly released 21.5.0](https://github.com/twisted/treq/releases/tag/release-21.5.0).

This drops support for Python 2.7 and Python 3.5.